### PR TITLE
Fix/custom local

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation Status](https://img.shields.io/badge/docs-latest-blue.svg)](https://verdenroz.github.io/chimeric/)
 [![CI](https://github.com/Verdenroz/chimeric/workflows/CI/badge.svg)](https://github.com/Verdenroz/chimeric/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/Verdenroz/chimeric/branch/main/graph/badge.svg)](https://codecov.io/gh/Verdenroz/chimeric)
+[![codecov](https://codecov.io/gh/Verdenroz/chimeric/graph/badge.svg?token=UOfsQnGQ3E)](https://codecov.io/gh/Verdenroz/chimeric)
 
 **Unified Python interface for multiple LLM providers with automatic provider detection and seamless switching.**
 
@@ -24,6 +24,7 @@
 [![Groq](https://img.shields.io/badge/Groq-F55036?logo=groq&logoColor=white)](https://groq.com/)
 [![Cohere](https://img.shields.io/badge/Cohere-39594A?logo=cohere&logoColor=white)](https://cohere.ai/)
 [![Cerebras](https://img.shields.io/badge/Cerebras-FF6B35?logo=cerebras&logoColor=white)](https://cerebras.ai/)
+[![OpenRouter](https://img.shields.io/badge/OpenRouter-6467F2?logo=openrouter&logoColor=white)](https://openrouter.ai/)
 
 ## 📖 Documentation
 
@@ -32,14 +33,7 @@ For detailed usage examples, configuration options, and advanced features, visit
 ## 📦 Installation
 
 ```bash
-# Base installation
 pip install chimeric
-
-# With specific providers
-pip install "chimeric[openai,anthropic,google]"
-
-# All providers
-pip install "chimeric[all]"
 ```
 
 Set your API keys as environment variables:
@@ -100,6 +94,25 @@ response = client.generate(
 print(response.content)
 ```
 
+### Structured Output
+
+```python
+from pydantic import BaseModel
+
+class Sentiment(BaseModel):
+    label: str
+    score: float
+    reasoning: str
+
+response = client.generate(
+    model="gpt-4o",
+    messages="Analyse the sentiment: 'This library is fantastic!'",
+    response_model=Sentiment,
+)
+print(response.parsed.label)    # "positive"
+print(response.parsed.score)    # 0.98
+```
+
 ### Multi-Provider Switching
 ```python
 # Seamlessly switch between providers
@@ -116,13 +129,14 @@ for model in models:
 
 ## 🔧 Key Features
 
-- **Multi-Provider Support**: Switch between 7 major AI providers seamlessly
+- **Multi-Provider Support**: Switch between 8 major AI providers seamlessly
 - **Automatic Detection**: Auto-detects available API keys from environment
 - **Unified Interface**: Consistent API across all providers
+- **Structured Output**: Parse responses directly into Pydantic models
 - **Streaming Support**: Real-time response streaming
 - **Function Calling**: Tool integration with decorators
 - **Async Support**: Full async/await compatibility
-- **Native Fallback**: Access provider-specific features when needed
+- **Local AI**: Connect to Ollama, LM Studio, or any OpenAI-compatible endpoint
 
 ## 🐛 Issues & Feature Requests
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation Status](https://img.shields.io/badge/docs-latest-blue.svg)](https://verdenroz.github.io/chimeric/)
 [![CI](https://github.com/Verdenroz/chimeric/workflows/CI/badge.svg)](https://github.com/Verdenroz/chimeric/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/Verdenroz/chimeric/branch/main/graph/badge.svg)](https://codecov.io/gh/Verdenroz/chimeric)
+[![codecov](https://codecov.io/gh/Verdenroz/chimeric/graph/badge.svg?token=UOfsQnGQ3E)](https://codecov.io/gh/Verdenroz/chimeric)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![basedpyright](https://img.shields.io/badge/basedpyright-checked-42b883)](https://github.com/DetachHead/basedpyright)
 [![codespell](https://img.shields.io/badge/codespell-checked-42b883)](https://github.com/codespell-project/codespell)

--- a/src/chimeric/__init__.py
+++ b/src/chimeric/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "Usage",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/chimeric/schema.py
+++ b/src/chimeric/schema.py
@@ -109,6 +109,7 @@ _FORMAT_BUILDERS: dict[Provider, _Builder] = {
     Provider.ANTHROPIC: _anthropic_format,
     Provider.GOOGLE: _google_format,
     Provider.COHERE: _cohere_format,
+    Provider.CUSTOM: _openai_format,
 }
 
 # ---------------------------------------------------------------------------

--- a/src/chimeric/types.py
+++ b/src/chimeric/types.py
@@ -80,6 +80,7 @@ class Provider(Enum):
     GROK = "grok"
     GROQ = "groq"
     OPENROUTER = "openrouter"
+    CUSTOM = "custom"
 
 
 ###################


### PR DESCRIPTION
## Summary

- Adds `CUSTOM = "custom"` to the `Provider` enum so that the custom local endpoint registered via `base_url=` is a valid enum member.
- Registers `Provider.CUSTOM: _openai_format` in `_FORMAT_BUILDERS` so that structured outputs (`response_model=`) work against any OpenAI-compatible local server (llama.cpp, llama-swap, Ollama, etc.).
- Fixes the `providers` property, which iterates all registered providers and calls `Provider(name)` — this would crash whenever a custom endpoint was configured.

## Breaking Changes

None

## Test Plan

- [x] `Chimeric(base_url="http://127.0.0.1:12434/v1").list_models()` returns models without error
- [x] `client.generate(model=..., messages=..., response_model=MyModel)` parses structured output from a local provider

## Checklist

- [x] Tests pass (`nox -s tests`)
- [x] Coverage ≥ 80%
- [x] Docs updated (if public API changed)
- [x] No hardcoded secrets or credentials
